### PR TITLE
Make deployments private

### DIFF
--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -1,12 +1,15 @@
 module.exports = handlePullRequestChange
 
 async function handlePullRequestChange (context) {
-  const {title, html_url: htmlUrl, head} = context.payload.pull_request
-  const isWip = containsWIP(title) || await labelsContainWIP(context) || await commitsContainWIP(context)
+  const {pull_request: {title, head, number, labels}, repository} = context.payload
+  const labelNames = labels.map(label => label.name)
+  const isWip = containsWIP(title) || labelNames.some(containsWIP) || await commitsContainWIP(context)
   const status = isWip ? 'pending' : 'success'
 
-  if (!context.payload.repository.private) {
-    console.log(`Updating PR "${title}" (${htmlUrl}): ${status}`)
+  if (context.payload.repository.private) {
+    console.log(`${repository.owner.login}/<private>#${number} — ${status}`)
+  } else {
+    console.log(`${repository.full_name}#${number} "${title}" — ${status}`)
   }
 
   context.github.repos.createStatus(context.repo({
@@ -24,10 +27,6 @@ async function commitsContainWIP (context) {
   }))
 
   return commits.data.map(element => element.commit.message).some(containsWIP)
-}
-
-async function labelsContainWIP (context) {
-  return context.payload.pull_request.labels.map(label => label.name).some(containsWIP)
 }
 
 function containsWIP (string) {

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -2,7 +2,7 @@ module.exports = handlePullRequestChange
 
 async function handlePullRequestChange (context) {
   const {title, html_url: htmlUrl, head} = context.payload.pull_request
-  const isWip = containsWIP(title) || await commitsContainWIP(context) || await labelsContainWIP(context)
+  const isWip = containsWIP(title) || await labelsContainWIP(context) || await commitsContainWIP(context)
   const status = isWip ? 'pending' : 'success'
 
   if (!context.payload.repository.private) {
@@ -27,16 +27,7 @@ async function commitsContainWIP (context) {
 }
 
 async function labelsContainWIP (context) {
-  // workaround for https://github.com/wip/app/issues/76
-  if (context.payload.repository.private) {
-    return
-  }
-
-  const labels = await context.github.issues.getIssueLabels(context.repo({
-    number: context.payload.pull_request.number
-  }))
-
-  return labels.data.map(label => label.name).some(containsWIP)
+  return context.payload.pull_request.labels.map(label => label.name).some(containsWIP)
 }
 
 function containsWIP (string) {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,8 +5,8 @@ now="npx now --debug --token=$NOW_TOKEN"
 echo "$ now rm --safe --yes wip"
 $now rm --safe --yes wip
 
-echo "$ now --public"
-$now --public
+echo "$ now"
+$now
 
 echo "$ now alias"
 $now alias

--- a/test/unit/lib/handle-pull-request-change.test.js
+++ b/test/unit/lib/handle-pull-request-change.test.js
@@ -7,7 +7,8 @@ describe('handlePullRequestChange', () => {
       payload: {
         pull_request: {
           head: { sha: 'sha' },
-          title: prTitle
+          title: prTitle,
+          labels: []
         },
         repository: {
           private: true
@@ -40,9 +41,7 @@ describe('handlePullRequestChange', () => {
   const createMockLabelContext = labelName => {
     const context = createMockContext('Example PR title')
 
-    context.github.issues.getIssueLabels = jest.fn().mockReturnValue({
-      data: [{ name: labelName }]
-    })
+    context.payload.pull_request.labels = [{ name: labelName }]
 
     return context
   }
@@ -112,14 +111,14 @@ describe('handlePullRequestChange', () => {
     expect(context.repo).lastCalledWith(successStatusObject)
   })
 
-  it.skip('(blocked by #76) creates pending status if a label contains `wip`', async () => {
+  it('creates pending status if a label contains `wip`', async () => {
     const context = createMockLabelContext('WIP')
     await handlePullRequestChange(context)
 
     expect(context.repo).lastCalledWith(pendingStatusObject)
   })
 
-  it.skip('(blocked by #76) creates pending status if a label contains `do not merge`', async () => {
+  it('creates pending status if a label contains `do not merge`', async () => {
     const context = createMockLabelContext('do not merge')
     await handlePullRequestChange(context)
 


### PR DESCRIPTION
Right now, the logs of the WIP app are public. My thinking was that it would help folks to debug their own problems. But I was convinced that exposing any kind of logs can prevent people to use the app altogether, so I decided to make the private after all. I’m looking into ways to make the logs accessible back to the user in different ways, stay tuned :)