### PR TITLE
remove emoji from commit status description

### DIFF
--- a/lib/legacy/overwrite-commit-status.js
+++ b/lib/legacy/overwrite-commit-status.js
@@ -24,8 +24,8 @@ async function overwriteCommitStatus (context) {
   await context.github.repos.createStatus(context.repo({
     sha,
     state: 'success',
-    target_url: 'https://github.com/wip/app/issues/89#notes-on-update-to-marketplace-version',
-    description: 'Legacy commit status override — see details 👉',
+    target_url: 'https://github.com/wip/app/issues/124',
+    description: 'Legacy commit status override — see details',
     context: getConfig().name
   }))
 


### PR DESCRIPTION
It caused "description contains unicode characters above 0xffff" errors