### PR TITLE
Making the status text more useful #149

### DIFF
--- a/lib/free/set-status.js
+++ b/lib/free/set-status.js
@@ -12,7 +12,7 @@ function setStatusFree (newStatus, context) {
     head_sha: pullRequest.head.sha,
     status: 'in_progress',
     output: {
-      title: `Title contains ${newStatus.match === '🚧' ? 'a construction sign!' : `"${newStatus.match}"`}`,
+      title: `Title contains ${newStatus.match === '🚧' ? 'a construction emoji' : `"${newStatus.match}"`}`,
       summary: `The title "${pullRequest.title}" contains "${newStatus.match}".`,
       text: `By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".
       

--- a/lib/free/set-status.js
+++ b/lib/free/set-status.js
@@ -12,7 +12,7 @@ function setStatusFree (newStatus, context) {
     head_sha: pullRequest.head.sha,
     status: 'in_progress',
     output: {
-      title: 'Work in progress',
+      title: `Title contains ${newStatus.match === '🚧' ? 'a construction sign!' : `"${newStatus.match}"`}`,
       summary: `The title "${pullRequest.title}" contains "${newStatus.match}".`,
       text: `By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".
       

--- a/lib/pro/set-status.js
+++ b/lib/pro/set-status.js
@@ -16,12 +16,11 @@ function setStatusPro (newStatus, context) {
 
   let output = gemoji.unicode[newStatus.match]
 
-  if (output === undefined) { 
-    output = `"${newStatus.match}"` //Text match
+  if (output === undefined) {
+    output = `"${newStatus.match}"` // Text match
   } else {
-    output = `a ${output.name} emoji` //Emoji match
+    output = `a ${output.name} emoji` // Emoji match
   }
-  
 
   const checkOptions = {
     name: name,

--- a/lib/pro/set-status.js
+++ b/lib/pro/set-status.js
@@ -2,7 +2,7 @@ module.exports = setStatusPro
 
 const getAppConfig = require('../app-config')
 const PRO_PLAN_FOR_FREE = require('../../pro-plan-for-free')
-const emojiText = require('emoji-text')
+const gemoji = require('gemoji')
 
 const locationLabel = {
   title: 'title',
@@ -14,20 +14,14 @@ function setStatusPro (newStatus, context) {
   const { repository, pull_request: pullRequest } = context.payload
   const { name } = getAppConfig()
 
-  let output = null
+  let output = gemoji.unicode[newStatus.match]
 
-  let emojiFound = false
-
-  output = emojiText.convert(newStatus.match, {
-    callback: function (emoji, data) {
-      emojiFound = true
-      return `a ${data.description.toLowerCase()} emoji!`
-    }
-  })
-
-  if (!emojiFound) {
-    output = `"${newStatus.match}"`
+  if (output === undefined) { 
+    output = `"${newStatus.match}"` //Text match
+  } else {
+    output = `a ${output.name} emoji` //Emoji match
   }
+  
 
   const checkOptions = {
     name: name,

--- a/lib/pro/set-status.js
+++ b/lib/pro/set-status.js
@@ -19,7 +19,7 @@ function setStatusPro (newStatus, context) {
     head_branch: '', // workaround for https://github.com/octokit/rest.js/issues/874
     head_sha: pullRequest.head.sha,
     output: {
-      title: 'Work in progress',
+      title: `Title contains ${newStatus.match === '🚧' ? 'a construction sign!' : `"${newStatus.match}"`}`,
       summary: `The ${locationLabel[newStatus.location]} "${newStatus.text}" contains "${newStatus.match}".
 
   You can override the status by adding "@wip ready for review" to the end of the [pull request description](${pullRequest.html_url}#discussion_bucket).`,

--- a/lib/pro/set-status.js
+++ b/lib/pro/set-status.js
@@ -2,6 +2,7 @@ module.exports = setStatusPro
 
 const getAppConfig = require('../app-config')
 const PRO_PLAN_FOR_FREE = require('../../pro-plan-for-free')
+const emojiText = require('emoji-text')
 
 const locationLabel = {
   title: 'title',
@@ -13,13 +14,28 @@ function setStatusPro (newStatus, context) {
   const { repository, pull_request: pullRequest } = context.payload
   const { name } = getAppConfig()
 
+  let output = null
+
+  let emojiFound = false
+
+  output = emojiText.convert(newStatus.match, {
+    callback: function (emoji, data) {
+      emojiFound = true
+      return `a ${data.description.toLowerCase()} emoji!`
+    }
+  })
+
+  if (!emojiFound) {
+    output = `"${newStatus.match}"`
+  }
+
   const checkOptions = {
     name: name,
     status: 'in_progress',
     head_branch: '', // workaround for https://github.com/octokit/rest.js/issues/874
     head_sha: pullRequest.head.sha,
     output: {
-      title: `Title contains ${newStatus.match === '🚧' ? 'a construction sign!' : `"${newStatus.match}"`}`,
+      title: `Title contains ${output}`,
       summary: `The ${locationLabel[newStatus.location]} "${newStatus.text}" contains "${newStatus.match}".
 
   You can override the status by adding "@wip ready for review" to the end of the [pull request description](${pullRequest.html_url}#discussion_bucket).`,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/wip/app#readme",
   "dependencies": {
-    "emoji-text": "^0.2.6",
+    "gemoji": "^4.2.1",
     "logdna-bunyan": "^1.0.1",
     "probot": "^7.0.0",
     "probot-config": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/wip/app#readme",
   "dependencies": {
+    "emoji-text": "^0.2.6",
     "logdna-bunyan": "^1.0.1",
     "probot": "^7.0.0",
     "probot-config": "^1.0.0"

--- a/test/integration/free-plan-test.js
+++ b/test/integration/free-plan-test.js
@@ -96,7 +96,7 @@ test('new pull request with "[WIP] Test" title', async function (t) {
   // create new check run
   const createCheckParams = this.githubMock.checks.create.lastCall.arg
   t.is(createCheckParams.status, 'in_progress')
-  t.is(createCheckParams.output.title, 'Work in progress')
+  t.is(createCheckParams.output.title, 'Title contains "WIP"')
   t.match(createCheckParams.output.summary, /The title "\[WIP\] Test" contains "WIP"/)
   t.notMatch(createCheckParams.output.summary, /You can override the status by adding "@wip ready for review"/)
 
@@ -117,7 +117,7 @@ test('new pull request with "[Work in Progress] Test" title', async function (t)
   // create new check run
   const createCheckParams = this.githubMock.checks.create.lastCall.arg
   t.is(createCheckParams.status, 'in_progress')
-  t.is(createCheckParams.output.title, 'Work in progress')
+  t.is(createCheckParams.output.title, 'Title contains "Work in Progress"')
   t.match(createCheckParams.output.summary, /The title "\[Work in Progress\] Test" contains "Work in Progress"/)
   t.notMatch(createCheckParams.output.summary, /You can override the status by adding "@wip ready for review"/)
 
@@ -136,7 +136,7 @@ test('new pull request with "🚧 Test" title', async function (t) {
   // create new check run
   const createCheckParams = this.githubMock.checks.create.lastCall.arg
   t.is(createCheckParams.status, 'in_progress')
-  t.is(createCheckParams.output.title, 'Work in progress')
+  t.is(createCheckParams.output.title, 'Title contains a construction sign!')
   t.match(createCheckParams.output.summary, /The title "🚧 Test" contains "🚧"/)
   t.notMatch(createCheckParams.output.summary, /You can override the status by adding "@wip ready for review"/)
 

--- a/test/integration/free-plan-test.js
+++ b/test/integration/free-plan-test.js
@@ -136,7 +136,7 @@ test('new pull request with "🚧 Test" title', async function (t) {
   // create new check run
   const createCheckParams = this.githubMock.checks.create.lastCall.arg
   t.is(createCheckParams.status, 'in_progress')
-t.is(createCheckParams.output.title, 'Title contains a construction emoji')
+  t.is(createCheckParams.output.title, 'Title contains a construction emoji')
   t.match(createCheckParams.output.summary, /The title "🚧 Test" contains "🚧"/)
   t.notMatch(createCheckParams.output.summary, /You can override the status by adding "@wip ready for review"/)
 

--- a/test/integration/free-plan-test.js
+++ b/test/integration/free-plan-test.js
@@ -136,7 +136,7 @@ test('new pull request with "🚧 Test" title', async function (t) {
   // create new check run
   const createCheckParams = this.githubMock.checks.create.lastCall.arg
   t.is(createCheckParams.status, 'in_progress')
-  t.is(createCheckParams.output.title, 'Title contains a construction sign!')
+t.is(createCheckParams.output.title, 'Title contains a construction emoji')
   t.match(createCheckParams.output.summary, /The title "🚧 Test" contains "🚧"/)
   t.notMatch(createCheckParams.output.summary, /You can override the status by adding "@wip ready for review"/)
 

--- a/test/integration/pro-plan-test.js
+++ b/test/integration/pro-plan-test.js
@@ -240,7 +240,7 @@ test('custom term: 🚧', async function (t) {
   t.is(createCheckParams.status, 'in_progress')
   t.is(createCheckParams.completed_at, undefined)
   t.is(createCheckParams.status, 'in_progress')
-  t.is(createCheckParams.output.title, 'Title contains a construction sign!')
+  t.is(createCheckParams.output.title, 'Title contains a construction sign emoji!')
   t.match(createCheckParams.output.summary, /The title "🚧 Test" contains "🚧"/)
   t.match(createCheckParams.output.summary, /You can override the status by adding "@wip ready for review"/)
   t.match(createCheckParams.output.text, /<td>🚧<\/td>/)

--- a/test/integration/pro-plan-test.js
+++ b/test/integration/pro-plan-test.js
@@ -240,7 +240,7 @@ test('custom term: 🚧', async function (t) {
   t.is(createCheckParams.status, 'in_progress')
   t.is(createCheckParams.completed_at, undefined)
   t.is(createCheckParams.status, 'in_progress')
-  t.is(createCheckParams.output.title, 'Title contains a construction sign emoji!')
+  t.is(createCheckParams.output.title, 'Title contains a construction emoji')
   t.match(createCheckParams.output.summary, /The title "🚧 Test" contains "🚧"/)
   t.match(createCheckParams.output.summary, /You can override the status by adding "@wip ready for review"/)
   t.match(createCheckParams.output.text, /<td>🚧<\/td>/)

--- a/test/integration/pro-plan-test.js
+++ b/test/integration/pro-plan-test.js
@@ -112,7 +112,7 @@ test('new pull request with "[WIP] Test" title', async function (t) {
     description: 'override status to "success"',
     identifier: 'override:1'
   }])
-  t.is(createCheckParams.output.title, 'Work in progress')
+  t.is(createCheckParams.output.title, 'Title contains "WIP"')
   t.match(createCheckParams.output.summary, /The title "\[WIP\] Test" contains "WIP"/)
   t.match(createCheckParams.output.summary, /You can override the status by adding "@wip ready for review"/)
 
@@ -240,7 +240,7 @@ test('custom term: 🚧', async function (t) {
   t.is(createCheckParams.status, 'in_progress')
   t.is(createCheckParams.completed_at, undefined)
   t.is(createCheckParams.status, 'in_progress')
-  t.is(createCheckParams.output.title, 'Work in progress')
+  t.is(createCheckParams.output.title, 'Title contains a construction sign!')
   t.match(createCheckParams.output.summary, /The title "🚧 Test" contains "🚧"/)
   t.match(createCheckParams.output.summary, /You can override the status by adding "@wip ready for review"/)
   t.match(createCheckParams.output.text, /<td>🚧<\/td>/)


### PR DESCRIPTION
This PR #149 updates the title of the bot's check to be a little less repetitive. Unit tests were also updated to reflect this change.

Since emojis don't seem to work in the title (even with `:construction:`) this is how they look:
![image](https://user-images.githubusercontent.com/15106748/49417588-54f94e80-f74c-11e8-8e21-e18877048137.png)

And everything else will look like:
![image](https://user-images.githubusercontent.com/15106748/49417618-75290d80-f74c-11e8-917a-656e41f87c1c.png)

Feedback is appreciated!

closes #149