### PR TITLE
Return 'pro' always for GHES installations

### DIFF
--- a/lib/get-plan.js
+++ b/lib/get-plan.js
@@ -15,6 +15,13 @@ async function getPlan (robot, owner) {
     return 'pro'
   }
 
+  // For GitHub Enterprise Server (GHES), always return 'pro'
+  // This is because /marketplace_listing API routes
+  // are not available on GHES
+  if (process.env.GHE_HOST) {
+    return 'pro'
+  }
+
   const authenticatedAsApp = await robot.auth()
   try {
     const {

--- a/test/unit/get-plan-test.js
+++ b/test/unit/get-plan-test.js
@@ -1,5 +1,18 @@
 const proxyquire = require('proxyquire').noCallThru()
-const { test } = require('tap')
+const { beforeEach, afterEach, test } = require('tap')
+
+beforeEach((done, t) => {
+  // Preserve GHE_HOST value before removal
+  t.context.GHE_HOST = process.env.GHE_HOST
+  delete process.env.GHE_HOST
+  done()
+})
+
+afterEach((done, t) => {
+  // Restore initial GHE_HOST value
+  process.env.GHE_HOST = t.context.GHE_HOST
+  done()
+})
 
 test('returns "pro" if account is enabled manually', async function (t) {
   const getPlan = proxyquire('../../lib/get-plan', {
@@ -7,6 +20,18 @@ test('returns "pro" if account is enabled manually', async function (t) {
   })
   const app = {}
   const owner = { login: 'foo' }
+  const plan = await getPlan(app, owner)
+
+  t.is(plan, 'pro')
+  t.end()
+})
+
+test('returns "pro" for GitHub Enterprise Server installations', async function (t) {
+  const getPlan = require('../../lib/get-plan')
+  const app = {}
+  const owner = { login: 'foo' }
+
+  process.env.GHE_HOST = true
   const plan = await getPlan(app, owner)
 
   t.is(plan, 'pro')


### PR DESCRIPTION
:wave: I'm working on a GitHub Enterprise Server-compatible version of WIP, I noticed that the `getPlan` is failing for GHES since there is no concept of a Marketplace listing.

Here's a 🚧 PR to address that, it felt reasonable to default the plan to `pro` for this type of user.