### PR TITLE
End the beta preview

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,6 +1,6 @@
 {
-  "name": "wip-beta",
-  "alias": "wip-beta",
+  "name": "wip",
+  "alias": "wip",
   "scale": {
     "all": {
       "min": 1,
@@ -8,15 +8,15 @@
     }
   },
   "env": {
-    "APP_ID": "@beta-app-id",
-    "APP_NAME": "WIP (beta)",
+    "APP_ID": "@app-id",
+    "APP_NAME": "WIP",
     "DISABLE_STATS": "true",
     "LOG_LEVEL": "fatal",
     "LOGDNA_API_KEY": "@logdna-api-key",
     "NODE_ENV": "production",
-    "PRIVATE_KEY": "@beta-private-key",
+    "PRIVATE_KEY": "@private-key",
     "REDIS_URL": "@redis-url",
     "SENTRY_DSN": "@sentry-dsn",
-    "WEBHOOK_SECRET": "@beta-webhook-secret"
+    "WEBHOOK_SECRET": "@webhook-secret"
   }
 }


### PR DESCRIPTION
You can test the current beta preview of the new features by installing the [WIP (beta)](https://github.com/apps/wip-beta) app.

The new features are

1. The legacy support for commit status is no more. Users must accept the new permissions to continue using WIP
2. Custom check run actions have been removed. With that, WIP now longer requires write permission pull requests
3. When installing or adding new repositories to your installation, all currently open pull requests will be update by WIP

I’d appreciate if you could give the beta a try 🙏  You can install the `WIP` and the `WIP (beta)` app side-by-side.

Thank you :)