### PR TITLE
Add Acts project

### DIFF
--- a/pro-plan-for-free.js
+++ b/pro-plan-for-free.js
@@ -9,5 +9,6 @@ module.exports = [
   'itspugle', // 2018-10-24: Student creating tools to better enable volunteer groups,
   'urbanengine', // 2019-03-29: non-profit organization helping startups & small businesses network and grow within their community
   'moonsmile', // 2019-9-1: Student writing tools to learn, I promise i will pay when I finish my project.
-  'apache' // 2020-01-01: non-profit corporation to support Apache software projects
+  'apache', // 2020-01-01: non-profit corporation to support Apache software projects
+  'acts-project' // 2020-03-30: Generic track reconstruction framework for high energy physics
 ]


### PR DESCRIPTION
Hey! We're developing a general purpose experiment agnostic open-source toolkit for track reconstruction, specifically geared towards high energy particle physics.

We recently migrated from CERN's internal [Gitlab instance](https://gitlab.cern.ch/acts/acts-core) to [Github](https://github.com/acts-project/acts), and currently use the WIP app. We'd be interested in using a `WIP` label for better categorization of issues, and we don't really have a budget, so I thought I'd ask if it's fine to add the org.

If this is not a valid excuse, feel free to close this PR obviously.