### PR TITLE
Update 404 donorbox links

### DIFF
--- a/lib/free/set-status.js
+++ b/lib/free/set-status.js
@@ -21,7 +21,7 @@ function setStatusFree(newStatus, context) {
       summary: `The title "${pullRequest.title}" contains "${newStatus.match}".`,
       text: `By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".
 
-You can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://donorbox.org/supportpf2019-fundraising-campaign) – one of the most diverse and impactful Open Source community there is.`,
+You can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://p5js.org/download/support.html) – one of the most diverse and impactful Open Source community there is.`,
     },
     // workaround random "Bad Credentials" errors
     // https://github.community/t5/GitHub-API-Development-and/Random-401-errors-after-using-freshly-generated-installation/m-p/22905/highlight/true#M1596

--- a/lib/pro/set-status.js
+++ b/lib/pro/set-status.js
@@ -104,7 +104,7 @@ Read more about [WIP configuration](https://github.com/wip/app#configuration)`,
     checkOptions.output.summary += `
   ### 🆓💸 The account ${repository.owner.login} is [enabled for the pro plan for free](https://github.com/wip/app/blob/master/pro-plan-for-free.js)
 
-  Please consider [signing up for the pro plan](https://github.com/marketplace/wip), all revenue is donated to [Processing | p5.js](https://donorbox.org/supportpf2019-fundraising-campaign) – one of the most diverse and impactful Open Source community there is.`;
+  Please consider [signing up for the pro plan](https://github.com/marketplace/wip), all revenue is donated to [Processing | p5.js](https://p5js.org/download/support.html) – one of the most diverse and impactful Open Source community there is.`;
   }
 
   return context.octokit.checks.create(context.repo(checkOptions));

--- a/test/integration/installation-test.js
+++ b/test/integration/installation-test.js
@@ -145,7 +145,7 @@ test("installation", async function (t) {
         output: {
           title: "Ready for review",
           summary: "No match found based on configuration",
-          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://donorbox.org/supportpf2019-fundraising-campaign) – one of the most diverse and impactful Open Source community there is.',
+          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://p5js.org/download/support.html) – one of the most diverse and impactful Open Source community there is.',
         },
         conclusion: "success",
         completed_at: "1970-01-01T00:00:00.000Z",
@@ -166,7 +166,7 @@ test("installation", async function (t) {
         output: {
           title: 'Title contains "WIP"',
           summary: 'The title "[WIP] Test" contains "WIP".',
-          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://donorbox.org/supportpf2019-fundraising-campaign) – one of the most diverse and impactful Open Source community there is.',
+          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://p5js.org/download/support.html) – one of the most diverse and impactful Open Source community there is.',
         },
       });
 
@@ -333,7 +333,7 @@ test("repositories added", async function (t) {
         output: {
           title: "Ready for review",
           summary: "No match found based on configuration",
-          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://donorbox.org/supportpf2019-fundraising-campaign) – one of the most diverse and impactful Open Source community there is.',
+          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://p5js.org/download/support.html) – one of the most diverse and impactful Open Source community there is.',
         },
         conclusion: "success",
         completed_at: "1970-01-01T00:00:00.000Z",
@@ -354,7 +354,7 @@ test("repositories added", async function (t) {
         output: {
           title: 'Title contains "WIP"',
           summary: 'The title "[WIP] Test" contains "WIP".',
-          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://donorbox.org/supportpf2019-fundraising-campaign) – one of the most diverse and impactful Open Source community there is.',
+          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://p5js.org/download/support.html) – one of the most diverse and impactful Open Source community there is.',
         },
       });
 
@@ -373,7 +373,7 @@ test("repositories added", async function (t) {
         output: {
           title: "Ready for review",
           summary: "No match found based on configuration",
-          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://donorbox.org/supportpf2019-fundraising-campaign) – one of the most diverse and impactful Open Source community there is.',
+          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://p5js.org/download/support.html) – one of the most diverse and impactful Open Source community there is.',
         },
         conclusion: "success",
         completed_at: "1970-01-01T00:00:00.000Z",
@@ -394,7 +394,7 @@ test("repositories added", async function (t) {
         output: {
           title: 'Title contains "WIP"',
           summary: 'The title "[WIP] Test" contains "WIP".',
-          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://donorbox.org/supportpf2019-fundraising-campaign) – one of the most diverse and impactful Open Source community there is.',
+          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://p5js.org/download/support.html) – one of the most diverse and impactful Open Source community there is.',
         },
       });
 
@@ -509,7 +509,7 @@ test("permissions accepted", async function (t) {
         output: {
           title: "Ready for review",
           summary: "No match found based on configuration",
-          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://donorbox.org/supportpf2019-fundraising-campaign) – one of the most diverse and impactful Open Source community there is.',
+          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://p5js.org/download/support.html) – one of the most diverse and impactful Open Source community there is.',
         },
         conclusion: "success",
         completed_at: "1970-01-01T00:00:00.000Z",
@@ -530,7 +530,7 @@ test("permissions accepted", async function (t) {
         output: {
           title: 'Title contains "WIP"',
           summary: 'The title "[WIP] Test" contains "WIP".',
-          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://donorbox.org/supportpf2019-fundraising-campaign) – one of the most diverse and impactful Open Source community there is.',
+          text: 'By default, WIP only checks the pull request title for the terms "WIP", "Work in progress" and "🚧".\n\nYou can configure both the terms and the location that the WIP app will look for by signing up for the pro plan: https://github.com/marketplace/wip. All revenue will be donated to [Processing | p5.js](https://p5js.org/download/support.html) – one of the most diverse and impactful Open Source community there is.',
         },
       });
 


### PR DESCRIPTION
The current link to p5js donation points to https://donorbox.org/supportpf2019-fundraising-campaign, which is a 404, updated all links to point to https://p5js.org/download/support.html