### PR TITLE
Add GitHub Sponsors link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,11 @@ The logo was created by [Micah Ilbery](https://github.com/micahilbery).
 ## Legal
 
 License: [Apache 2.0](LICENSE). [Privacy Policy](https://github.com/wip/policies/blob/master/PRIVACY.md). [Security Policy](https://github.com/wip/policies/blob/master/SECURITY.md). [Code of Conduct](CODE_OF_CONDUCT.md)
+
+
+## Support My Work
+
+If you appreciate my work and want to support me, consider becoming a sponsor on GitHub!
+
+[![Sponsor me on GitHub](https://img.shields.io/badge/Sponsor_me_on-GitHub-brightgreen)](https://github.com/sponsors/gr2m)
+


### PR DESCRIPTION
### Summary

This pull request adds a link to support me via GitHub Sponsors in the `README.md` file. The link includes a badge that encourages users to become sponsors.

### Changes Made

- Added a section titled "Support My Work" to the `README.md`.
- Included a badge image that links to my GitHub Sponsors page.

### Why This Change

Adding a sponsorship link provides an opportunity for users to support the development and maintenance of this project. It helps raise awareness about the option to sponsor and contributes to the sustainability of the project.

### Additional Notes

Feel free to customize the badge text or link if necessary. This change will help support ongoing development and improvements.

Thank you for considering this pull request!
