### PR TITLE
feat: add draft mode override for pull request status

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ export default function wip(app, log) {
       "pull_request.labeled",
       "pull_request.unlabeled",
       "pull_request.synchronize",
+      "pull_request.converted_to_draft",
+      "pull_request.ready_for_review",
       "merge_group.checks_requested",
     ],
     ({ octokit, payload }) =>

--- a/lib/common/has-status-change.js
+++ b/lib/common/has-status-change.js
@@ -23,7 +23,12 @@ export function hasStatusChange(newStatus, checkRuns) {
 
   const [{ conclusion, output }] = checkRuns;
   const isWip = conclusion !== "success";
-  const hasOverride = output && /override/.test(output.title);
+  const hasOverride = output && /\(override\)/.test(output.title);
+  const hasDraft = output && /draft mode override/.test(output.title);
 
-  return isWip !== newStatus.wip || hasOverride !== newStatus.override;
+  return (
+    isWip !== newStatus.wip ||
+    !!hasOverride !== !!newStatus.override ||
+    !!hasDraft !== !!newStatus.draft
+  );
 }

--- a/lib/free/set-status.js
+++ b/lib/free/set-status.js
@@ -33,7 +33,11 @@ You can configure both the terms and the location that the WIP app will look for
     },
   };
 
-  if (!newStatus.wip) {
+  if (newStatus.draft) {
+    checkOptions.output.title = "draft mode override";
+    checkOptions.output.summary =
+      "The pull request is in draft mode and will not be merged.";
+  } else if (!newStatus.wip) {
     checkOptions.status = "completed";
     checkOptions.conclusion = "success";
     checkOptions.completed_at = new Date().toISOString();

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -40,8 +40,10 @@ export default async function handlePullRequestChange({
       getExistingCheckRuns({ octokit, payload }),
     ]);
 
-    const newStatus =
-      plan === "free"
+    // Draft PRs always override to WIP status, skip further checks
+    const newStatus = pr.draft
+      ? { wip: true, draft: true }
+      : plan === "free"
         ? await getStatusFree({ payload })
         : await getStatusPro({ octokit, payload });
     const shortUrl = mergeGroup

--- a/lib/logs/get-child.js
+++ b/lib/logs/get-child.js
@@ -32,6 +32,9 @@ export default function getChildLog({
     options.hasConfig = !!newStatus.hasCustomConfig;
     options.override = newStatus.override;
   }
+  if (newStatus.draft) {
+    options.draft = true;
+  }
   const childLog = log.child(options);
 
   return {
@@ -39,9 +42,15 @@ export default function getChildLog({
       childLog.info(getDuration(timeStart), `😐 ${shortUrl}`);
     },
     stateChanged() {
-      const logStatus = newStatus.override ? "❗️" : newStatus.wip ? "⏳" : "✅";
+      const logStatus = newStatus.draft
+        ? "📝"
+        : newStatus.override
+          ? "❗️"
+          : newStatus.wip
+            ? "⏳"
+            : "✅";
       let message = `${logStatus} ${shortUrl}`;
-      if (newStatus.wip) {
+      if (newStatus.wip && !newStatus.draft) {
         message += ` - "${newStatus.match}" found in ${newStatus.location}`;
       }
       childLog.info(getDuration(timeStart), message);

--- a/lib/pro/set-status.js
+++ b/lib/pro/set-status.js
@@ -69,7 +69,11 @@ Read more about [WIP configuration](https://github.com/wip/app#configuration)`,
     },
   };
 
-  if (!newStatus.wip) {
+  if (newStatus.draft) {
+    checkOptions.output.title = "draft mode override";
+    checkOptions.output.summary =
+      "The pull request is in draft mode and will not be merged.";
+  } else if (!newStatus.wip) {
     checkOptions.status = "completed";
     checkOptions.conclusion = "success";
     checkOptions.completed_at = new Date().toISOString();

--- a/test/integration/events/new-draft-pull-request-with-test-title.json
+++ b/test/integration/events/new-draft-pull-request-with-test-title.json
@@ -1,0 +1,32 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "opened",
+    "pull_request": {
+      "title": "Test",
+      "number": 1,
+      "draft": true,
+      "head": {
+        "sha": "sha123"
+      },
+      "labels": []
+    },
+    "repository": {
+      "id": 1,
+      "name": "app",
+      "full_name": "wip/app",
+      "private": false,
+      "owner": {
+        "id": 1,
+        "login": "wip",
+        "type": "Organization"
+      }
+    },
+    "organization": {
+      "login": "wip"
+    },
+    "installation": {
+      "id": 1
+    }
+  }
+}

--- a/test/integration/events/new-draft-pull-request-with-wip-title.json
+++ b/test/integration/events/new-draft-pull-request-with-wip-title.json
@@ -1,0 +1,32 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "opened",
+    "pull_request": {
+      "title": "[WIP] Test",
+      "number": 1,
+      "draft": true,
+      "head": {
+        "sha": "sha123"
+      },
+      "labels": []
+    },
+    "repository": {
+      "id": 1,
+      "name": "app",
+      "full_name": "wip/app",
+      "private": false,
+      "owner": {
+        "id": 1,
+        "login": "wip",
+        "type": "Organization"
+      }
+    },
+    "organization": {
+      "login": "wip"
+    },
+    "installation": {
+      "id": 1
+    }
+  }
+}

--- a/test/integration/events/pull-request-converted-to-draft.json
+++ b/test/integration/events/pull-request-converted-to-draft.json
@@ -1,0 +1,32 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "converted_to_draft",
+    "pull_request": {
+      "title": "Test",
+      "number": 1,
+      "draft": true,
+      "head": {
+        "sha": "sha123"
+      },
+      "labels": []
+    },
+    "repository": {
+      "id": 1,
+      "name": "app",
+      "full_name": "wip/app",
+      "private": false,
+      "owner": {
+        "id": 1,
+        "login": "wip",
+        "type": "Organization"
+      }
+    },
+    "organization": {
+      "login": "wip"
+    },
+    "installation": {
+      "id": 1
+    }
+  }
+}

--- a/test/integration/events/pull-request-ready-for-review.json
+++ b/test/integration/events/pull-request-ready-for-review.json
@@ -1,0 +1,32 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "ready_for_review",
+    "pull_request": {
+      "title": "Test",
+      "number": 1,
+      "draft": false,
+      "head": {
+        "sha": "sha123"
+      },
+      "labels": []
+    },
+    "repository": {
+      "id": 1,
+      "name": "app",
+      "full_name": "wip/app",
+      "private": false,
+      "owner": {
+        "id": 1,
+        "login": "wip",
+        "type": "Organization"
+      }
+    },
+    "organization": {
+      "login": "wip"
+    },
+    "installation": {
+      "id": 1
+    }
+  }
+}

--- a/test/integration/free-plan-test.js
+++ b/test/integration/free-plan-test.js
@@ -636,3 +636,190 @@ test("404 from hasStatusChange check (not spam)", async function (t) {
   t.same(apiMock.activeMocks(), []);
   t.same(dotcomMock.activeMocks(), []);
 });
+
+test('draft pull request with "Test" title', async function (t) {
+  const mock = nock("https://api.github.com");
+  nockAccessToken(mock);
+
+  mock
+    // has no plan
+    .get("/marketplace_listing/accounts/1")
+    .reply(404)
+
+    // check for current status
+    .get("/repos/wip/app/commits/sha123/check-runs")
+    .query({
+      check_name: "WIP",
+    })
+    .reply(200, { check_runs: [] })
+
+    // create new check run
+    .post("/repos/wip/app/check-runs", (createCheckParams) => {
+      t.equal(createCheckParams.status, "in_progress");
+      t.equal(createCheckParams.output.title, "draft mode override");
+      t.match(
+        createCheckParams.output.summary,
+        /The pull request is in draft mode/,
+      );
+
+      return true;
+    })
+    .reply(201, {});
+
+  await app.webhooks.receive({
+    id: "1",
+    ...require("./events/new-draft-pull-request-with-test-title.json"),
+  });
+
+  t.same(mock.activeMocks(), []);
+});
+
+test('draft pull request with "[WIP] Test" title', async function (t) {
+  const mock = nock("https://api.github.com");
+  nockAccessToken(mock);
+
+  mock
+    // has no plan
+    .get("/marketplace_listing/accounts/1")
+    .reply(404)
+
+    // check for current status
+    .get("/repos/wip/app/commits/sha123/check-runs")
+    .query({
+      check_name: "WIP",
+    })
+    .reply(200, { check_runs: [] })
+
+    // create new check run
+    .post("/repos/wip/app/check-runs", (createCheckParams) => {
+      t.equal(createCheckParams.status, "in_progress");
+      t.equal(createCheckParams.output.title, "draft mode override");
+      t.match(
+        createCheckParams.output.summary,
+        /The pull request is in draft mode/,
+      );
+
+      return true;
+    })
+    .reply(201, {});
+
+  await app.webhooks.receive({
+    id: "1",
+    ...require("./events/new-draft-pull-request-with-wip-title.json"),
+  });
+
+  t.same(mock.activeMocks(), []);
+});
+
+test("pull request converted to draft", async function (t) {
+  const mock = nock("https://api.github.com");
+  nockAccessToken(mock);
+
+  mock
+    // has no plan
+    .get("/marketplace_listing/accounts/1")
+    .reply(404)
+
+    // check for current status
+    .get("/repos/wip/app/commits/sha123/check-runs")
+    .query({
+      check_name: "WIP",
+    })
+    .reply(200, {
+      check_runs: [
+        {
+          conclusion: "success",
+        },
+      ],
+    })
+
+    // create new check run
+    .post("/repos/wip/app/check-runs", (createCheckParams) => {
+      t.equal(createCheckParams.status, "in_progress");
+      t.equal(createCheckParams.output.title, "draft mode override");
+
+      return true;
+    })
+    .reply(201, {});
+
+  await app.webhooks.receive({
+    id: "1",
+    ...require("./events/pull-request-converted-to-draft.json"),
+  });
+
+  t.same(mock.activeMocks(), []);
+});
+
+test("pull request ready for review", async function (t) {
+  const mock = nock("https://api.github.com");
+  nockAccessToken(mock);
+
+  mock
+    // has no plan
+    .get("/marketplace_listing/accounts/1")
+    .reply(404)
+
+    // check for current status
+    .get("/repos/wip/app/commits/sha123/check-runs")
+    .query({
+      check_name: "WIP",
+    })
+    .reply(200, {
+      check_runs: [
+        {
+          output: {
+            title: "draft mode override",
+          },
+        },
+      ],
+    })
+
+    // create new check run
+    .post("/repos/wip/app/check-runs", (createCheckParams) => {
+      t.equal(createCheckParams.status, "completed");
+      t.equal(createCheckParams.conclusion, "success");
+      t.equal(createCheckParams.output.title, "Ready for review");
+
+      return true;
+    })
+    .reply(201, {});
+
+  await app.webhooks.receive({
+    id: "1",
+    ...require("./events/pull-request-ready-for-review.json"),
+  });
+
+  t.same(mock.activeMocks(), []);
+});
+
+test("draft pull request with existing draft check (no change)", async function (t) {
+  const mock = nock("https://api.github.com");
+  nockAccessToken(mock);
+
+  mock
+    // has no plan
+    .get("/marketplace_listing/accounts/1")
+    .reply(404)
+
+    // check for current status
+    .get("/repos/wip/app/commits/sha123/check-runs")
+    .query({
+      check_name: "WIP",
+    })
+    .reply(200, {
+      check_runs: [
+        {
+          output: {
+            title: "draft mode override",
+          },
+        },
+      ],
+    });
+
+  await app.webhooks.receive({
+    id: "1",
+    ...require("./events/new-draft-pull-request-with-test-title.json"),
+  });
+
+  t.same(mock.activeMocks(), []);
+});

--- a/test/integration/pro-plan-test.js
+++ b/test/integration/pro-plan-test.js
@@ -1357,3 +1357,200 @@ test("custom APP_NAME", async function (t) {
 
   t.same(mock.activeMocks(), []);
 });
+
+test('draft pull request with "Test" title', async function (t) {
+  const mock = nock("https://api.github.com");
+  nockAccessToken(mock);
+
+  mock
+    // has pro plan
+    .get("/marketplace_listing/accounts/1")
+    .reply(200, {
+      marketplace_purchase: {
+        plan: {
+          price_model: "FLAT_RATE",
+        },
+      },
+    })
+
+    // check for current status
+    .get("/repos/wip/app/commits/sha123/check-runs")
+    .query({
+      check_name: "WIP",
+    })
+    .reply(200, { check_runs: [] })
+
+    // create new check run
+    .post("/repos/wip/app/check-runs", (createCheckParams) => {
+      t.equal(createCheckParams.status, "in_progress");
+      t.equal(createCheckParams.output.title, "draft mode override");
+      t.match(
+        createCheckParams.output.summary,
+        /The pull request is in draft mode/,
+      );
+
+      return true;
+    })
+    .reply(201, {});
+
+  await app.webhooks.receive({
+    id: "1",
+    ...require("./events/new-draft-pull-request-with-test-title.json"),
+  });
+
+  // check resulting logs
+  const logParams = output[0];
+  t.equal(logParams.wip, true);
+  t.equal(logParams.draft, true);
+  t.equal(logParams.change, true);
+  t.equal(logParams.msg, "📝 wip/app#1");
+
+  t.same(mock.activeMocks(), []);
+});
+
+test('draft pull request with "[WIP] Test" title', async function (t) {
+  const mock = nock("https://api.github.com");
+  nockAccessToken(mock);
+
+  mock
+    // has pro plan
+    .get("/marketplace_listing/accounts/1")
+    .reply(200, {
+      marketplace_purchase: {
+        plan: {
+          price_model: "FLAT_RATE",
+        },
+      },
+    })
+
+    // check for current status
+    .get("/repos/wip/app/commits/sha123/check-runs")
+    .query({
+      check_name: "WIP",
+    })
+    .reply(200, { check_runs: [] })
+
+    // create new check run
+    .post("/repos/wip/app/check-runs", (createCheckParams) => {
+      t.equal(createCheckParams.status, "in_progress");
+      t.equal(createCheckParams.output.title, "draft mode override");
+
+      return true;
+    })
+    .reply(201, {});
+
+  await app.webhooks.receive({
+    id: "1",
+    ...require("./events/new-draft-pull-request-with-wip-title.json"),
+  });
+
+  // check resulting logs
+  const logParams = output[0];
+  t.equal(logParams.wip, true);
+  t.equal(logParams.draft, true);
+
+  t.same(mock.activeMocks(), []);
+});
+
+test("pull request converted to draft", async function (t) {
+  const mock = nock("https://api.github.com");
+  nockAccessToken(mock);
+
+  mock
+    // has pro plan
+    .get("/marketplace_listing/accounts/1")
+    .reply(200, {
+      marketplace_purchase: {
+        plan: {
+          price_model: "FLAT_RATE",
+        },
+      },
+    })
+
+    // check for current status
+    .get("/repos/wip/app/commits/sha123/check-runs")
+    .query({
+      check_name: "WIP",
+    })
+    .reply(200, {
+      check_runs: [
+        {
+          conclusion: "success",
+        },
+      ],
+    })
+
+    // create new check run
+    .post("/repos/wip/app/check-runs", (createCheckParams) => {
+      t.equal(createCheckParams.status, "in_progress");
+      t.equal(createCheckParams.output.title, "draft mode override");
+
+      return true;
+    })
+    .reply(201, {});
+
+  await app.webhooks.receive({
+    id: "1",
+    ...require("./events/pull-request-converted-to-draft.json"),
+  });
+
+  t.same(mock.activeMocks(), []);
+});
+
+test("pull request ready for review", async function (t) {
+  const mock = nock("https://api.github.com");
+  nockAccessToken(mock);
+
+  mock
+    // has pro plan
+    .get("/marketplace_listing/accounts/1")
+    .reply(200, {
+      marketplace_purchase: {
+        plan: {
+          price_model: "FLAT_RATE",
+        },
+      },
+    })
+
+    // has no config
+    .get("/repos/wip/app/contents/.github%2Fwip.yml")
+    .reply(404)
+    .get("/repos/wip/.github/contents/.github%2Fwip.yml")
+    .reply(404)
+
+    // List commits on a pull request
+    .get("/repos/wip/app/pulls/1/commits")
+    .reply(200, [])
+
+    // check for current status
+    .get("/repos/wip/app/commits/sha123/check-runs")
+    .query({
+      check_name: "WIP",
+    })
+    .reply(200, {
+      check_runs: [
+        {
+          output: {
+            title: "draft mode override",
+          },
+        },
+      ],
+    })
+
+    // create new check run
+    .post("/repos/wip/app/check-runs", (createCheckParams) => {
+      t.equal(createCheckParams.status, "completed");
+      t.equal(createCheckParams.conclusion, "success");
+      t.equal(createCheckParams.output.title, "Ready for review");
+
+      return true;
+    })
+    .reply(201, {});
+
+  await app.webhooks.receive({
+    id: "1",
+    ...require("./events/pull-request-ready-for-review.json"),
+  });
+
+  t.same(mock.activeMocks(), []);
+});


### PR DESCRIPTION
## Summary

Implement draft mode override for pull requests, allowing proper handling of draft status changes. This feature ensures status checks respect the draft state across both free and pro tiers.

## Changes

**Core Implementation (`index.js`)**

- Add draft mode override configuration

**Status Detection (`lib/common/has-status-change.js`)**

- Update status change detection to account for draft mode

**Free Plan Status (`lib/free/set-status.js`)**

- Modify status setting logic to handle draft mode overrides

**Pro Plan Status (`lib/pro/set-status.js`)**

- Modify status setting logic to handle draft mode overrides

**Pull Request Handling (`lib/handle-pull-request-change.js`)**

- Update pull request change handler to respect draft mode

**Logging (`lib/logs/get-child.js`)**

- Enhance child logger configuration for draft mode handling

**Test Fixtures (`test/fixtures/events/`)**

- Add new-draft-pull-request-with-test-title.json for draft PR with test title
- Add new-draft-pull-request-with-wip-title.json for draft PR with WIP title
- Add pull-request-converted-to-draft.json for conversion event
- Add pull-request-ready-for-review.json for ready event

**Integration Tests (`test/integration/`)**

- Add comprehensive free plan tests covering draft mode scenarios
- Add comprehensive pro plan tests covering draft mode scenarios

---

[Chat](https://open-agents.dev/sessions/EpnZMqbv5og0GmMzIxF5b/chats/GdiHXtYAPerizqDH7Dhq5) - Built with guidance from [Gregor Martynus](https://github.com/gr2m)